### PR TITLE
#162685653 chore(intergrate travis): Integrate TravisCI with readme 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+    - "3.7-dev"
+addons:
+  postgresql: "9.4"
+
+install:
+    - pip install -r requirements.txt
+
+before_script:
+    - psql -c "create database ahdatabase;" -U postgres
+    - python manage.py makemigrations
+    - python manage.py migrate
+
+script:
+    - coverage run --source='.' manage.py test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/andela/Ah-backend-guardians.svg?branch=develop)](https://travis-ci.org/andela/Ah-backend-guardians)
+
 Authors Haven - A Social platform for the creative at heart.
 =======
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 astroid==2.1.0
+coverage==4.5.2
 Django==2.1.5
 django-cors-middleware==1.3.1
 django-extensions==2.1.4
@@ -6,6 +7,7 @@ djangorestframework==3.9.0
 isort==4.3.4
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
+psycopg2==2.7.6.1
 PyJWT==1.7.1
 pylint==2.2.2
 pytz==2018.9


### PR DESCRIPTION
**What does this PR do?**
This PR delivers a chore that integrates Travis with the Authors Haven project

**Description of Task to be completed?**
Connecting and configuring Travis with GitHub to have a remote representation of the passing builds

**What are the relevant Pivotal Tracker stories?**
[#162685649](https://www.pivotaltracker.com/n/projects/2232496)


[Link to travis](https://travis-ci.org/andela/Ah-backend-guardians)


**Notes**
The build fails as there are no passing tests at the moment

**Screenshot:**

<img width="983" alt="screen shot 2019-01-08 at 4 35 50 pm" src="https://user-images.githubusercontent.com/30922279/50833868-a73d1900-1363-11e9-9c35-401258250e09.png">

