### PR TITLE
#162685656 Integrate Coveralls code coverage service with badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ before_script:
 
 script:
     - coverage run --source='.' manage.py test
+
+after_success:
+    - coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/andela/Ah-backend-guardians.svg?branch=develop)](https://travis-ci.org/andela/Ah-backend-guardians) [![Coverage Status](https://coveralls.io/repos/github/andela/Ah-backend-guardians/badge.svg?branch=ch-integrate-coveralls-162685656)](https://coveralls.io/github/andela/Ah-backend-guardians?branch=ch-integrate-coveralls-162685656)
+[![Build Status](https://travis-ci.org/andela/Ah-backend-guardians.svg?branch=develop)](https://travis-ci.org/andela/Ah-backend-guardians) [![Coverage Status](https://coveralls.io/repos/github/andela/Ah-backend-guardians/badge.svg?branch=develop)](https://coveralls.io/github/andela/Ah-backend-guardians?branch=develop)
 
 Authors Haven - A Social platform for the creative at heart.
 =======

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/andela/Ah-backend-guardians.svg?branch=develop)](https://travis-ci.org/andela/Ah-backend-guardians)
+[![Build Status](https://travis-ci.org/andela/Ah-backend-guardians.svg?branch=develop)](https://travis-ci.org/andela/Ah-backend-guardians) [![Coverage Status](https://coveralls.io/repos/github/andela/Ah-backend-guardians/badge.svg?branch=ch-integrate-coveralls-162685656)](https://coveralls.io/github/andela/Ah-backend-guardians?branch=ch-integrate-coveralls-162685656)
 
 Authors Haven - A Social platform for the creative at heart.
 =======


### PR DESCRIPTION
**What does this PR do?**
This PR delivers a chore that integrates Coveralls code coverage service

**Description of Task to be completed?**
Connecting and configuring _Coveralls_ with _GitHub_ and _Travis_ to have code test coverage after successful Travis build.

**What are the relevant pivotal tracker stories?**
[#162685649](https://www.pivotaltracker.com/story/show/162685656)

[Link to coveralls](https://coveralls.io/github/andela/Ah-backend-guardians)

**Screenshot:**
<img width="1374" alt="screen shot 2019-01-08 at 7 11 06 pm" src="https://user-images.githubusercontent.com/40206038/50843199-4b7d8a80-1379-11e9-8323-57d6806d81ee.png">

