### PR TITLE
#162685654 Configure app to use postgreSQL database

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+from decouple import config, Csv
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -19,12 +20,13 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '7pgozr2jn7zs_o%i8id6=rddie!*0f0qy3$oy$(8231i^4*@u3'
+SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+EMAIL_PORT = config('EMAIL_PORT')
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=Csv())
 
 # Application definition
 
@@ -81,8 +83,12 @@ WSGI_APPLICATION = 'authors.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': config('DB_NAME'),
+        'USER': config('DB_USER'),
+        'PASSWORD': config('DB_PASSWORD'),
+        'HOST': config('DB_HOST'),
+        'PORT': '',
     }
 }
 

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = config('SECRET_KEY')
 DEBUG = True
 EMAIL_PORT = config('EMAIL_PORT')
 
-ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=Csv())
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=lambda v: [s.strip() for s in v.split(',')])
 
 # Application definition
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ mccabe==0.6.1
 psycopg2==2.7.6.1
 PyJWT==1.7.1
 pylint==2.2.2
+python-decouple==3.1
 pytz==2018.9
 six==1.12.0
 wrapt==1.10.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ isort==4.3.4
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
 psycopg2==2.7.6.1
+psycopg2-binary==2.7.6.1
 PyJWT==1.7.1
 pylint==2.2.2
 python-decouple==3.1


### PR DESCRIPTION
**What does this PR do?**
This PR finishes a chore that integrates a postgreSQL database in the application.

**Description of Task to be completed?**
The application should use the postgreSQL database as it's default database as opposed to the default SQLite3 which comes with Django.

**What are the relevant Pivotal Tracker stories?**
[#162685654](https://www.pivotaltracker.com/story/show/162685654)

**How should it be manually tested?**
Run each of the following commands in your terminal in the respective order.

- `git clone https://github.com/andela/Ah-backend-guardians.git`
- `cd Ah-backend-guardians`
- `git checkout ch-upgrade-162685649`
- `virtualenv venv`
- `. venv/bin/activate`
- Create a database `psql -c "create database ahdatabase;" -U postgres`(assuming `postgres` is your admin database user.)
- Create a `.env` file on the root directory and add the data below, substituting each variable as appropriately described.

```
    SECRET_KEY=your-secret-key-here(this is got from your settings.py file)
    DB_NAME=your-database-name-here
    DB_USER=your-database-user-here
    DB_PASSWORD=your-database-password-here
    DB_HOST=your-host-here(most preferrably localhost or 127.0.0.1)
```

- Add the following variables to the same .env file as is.

```
    ALLOWED_HOSTS=.localhost, .herokuapp.com
    EMAIL_HOST=email_host
    EMAIL_HOST_USER=email_host_user
    EMAIL_HOST_PASSWORD=email_host_password
    EMAIL_PORT=EMAIL_PORT
```

- Run migrations `python manage.py makemigrations` then `python manage.py migrate`
- Run the app `python manage.py runserver`

You should be able to get back the output as in the screenshot.

**Screenshot**
![image](https://user-images.githubusercontent.com/38134382/50853231-be472f80-1392-11e9-818f-f6bc52da3490.png)