### PR TITLE
#162685671 User can view profiles

### DIFF
--- a/authors/apps/authentication/tests/test_validation.py
+++ b/authors/apps/authentication/tests/test_validation.py
@@ -19,7 +19,6 @@ class ValidationTest(BaseTestCase):
         """Test api  can't create user if password is invalid"""
 
         response = self.register_user(poor_conventions_password)
-        print(response.data['errors'])
 
         self.assertEqual(response.data['errors']['error'],
                          ["Ensure password has an uppercase, lowercase, "

--- a/authors/apps/profiles/tests/test_views.py
+++ b/authors/apps/profiles/tests/test_views.py
@@ -44,7 +44,6 @@ class RetrieveProfileTestCase(BaseTestCase):
 
 class EditProfileTestCase(BaseTestCase):
     def setUp(self):
-
         username1 = user1['username']
         username2 = user2['username']
         self.user = User.objects.get(username=username2)
@@ -57,7 +56,22 @@ class EditProfileTestCase(BaseTestCase):
         """
         self.client.force_authenticate(user=self.user)
         response = self.client.put(self.url1)
-        print(response.data)
         self.assertEqual(response.data['error'],
                          "You are not authorised to edit soultek's profile")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class ListProfileTestCase(BaseTestCase):
+    def setUp(self):
+        username1 = user1['username']
+        username2 = user2['username']
+        self.user = User.objects.get(username=username2)
+
+    def test_get_all_user_profiles(self):
+        """
+        Test whether a user can get all profiles
+        """
+        url = reverse("profiles:show_profile")
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,14 +1,14 @@
 from django.conf.urls import url, include
 from rest_framework.urlpatterns import format_suffix_patterns
-from .views import RetrieveProfileView, UpdateProfileView
+from .views import RetrieveProfileView, UpdateProfileView, ListProfileView
 from django.urls import path
 
 urlpatterns = {
-    path('profiles/<username>/',
-         RetrieveProfileView.as_view(), name="profile_details"),
-    path('profiles/<username>/edit/',
-         UpdateProfileView.as_view(), name="update_profile"),
-
+     path('profiles/', ListProfileView.as_view(), name="show_profile"),
+     path('profiles/<username>/',
+          RetrieveProfileView.as_view(), name="profile_details"),
+     path('profiles/<username>/edit/',
+          UpdateProfileView.as_view(), name="update_profile"),
 }
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -58,3 +58,13 @@ class UpdateProfileView(generics.UpdateAPIView):
                 'error':  exception_messages.get
                 ('edit_profile_not_permitted').format(username)
             })
+
+
+class ListProfileView(generics.ListAPIView):
+    """
+    Implements get all user profile endpoint
+    """
+    permission_classes = (IsAuthenticated, )
+    renderer_classes = (ProfileJSONRenderer,)
+    serializer_class = ProfileSerializer
+    queryset = Profile.objects.all()


### PR DESCRIPTION
#### What does this PR do?
PR enables users should be able to see the list and profiles of existing authors
#### Description of Task to be completed?
A logged in/authenticated user should be able to see the list and profiles of existing authors. 
#### How should this be manually tested?
Before testing run these commands in cmd

`git clone https://github.com/andela/Ah-backend-guardians.git`

`cd Ah-backend-guardians`

`git checkout ft-view-all-profiles-162685671`

`virtualenv env`

`. env/bin/activate`

`pip install -r requirements.txt`

1.  Create a postgres database and a `.env` file in your root directory and add the following configurations.
```
SECRET_KEY=andela_sjdndkjghdf78872

DB_NAME=your_database_name

DB_USER=database_user

DB_PASSWORD=database_password

DB_HOST=127.0.0.1

ALLOWED_HOSTS=.localhost, .herokuapp.com

EMAIL_PORT=587

EMAIL_HOST_USER = gauthorshaven@gmail.com

EMAIL_HOST_PASSWORD = guardiansauthors
```
2. Open Postman and type `http://localhost:8000/api/profiles/` in url text box. Select GET in methods drop down then click `SEND` button
#### What are the relevant pivotal tracker stories?
[#162685671](https://www.pivotaltracker.com/story/show/162685671)
#### Screenshots (if appropriate)
![screen shot 2019-01-21 at 2 44 57 pm](https://user-images.githubusercontent.com/13882936/51472680-35b19180-1d8b-11e9-8715-b1ca02570076.png)
