### PR TITLE
#163588288 Allow access to articles even for non-authenticated users

### DIFF
--- a/authors/apps/comments/models.py
+++ b/authors/apps/comments/models.py
@@ -14,14 +14,8 @@ class Comment(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now_add=True)
 
-    def __str__(self):
-        return str(self.author)
-
 
 class LikeComment(models.Model):
 
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     comment = models.ForeignKey(Comment, on_delete=models.CASCADE)
-
-    def __str__(self):
-        return str(self.user)

--- a/authors/apps/comments/tests/test_comments.py
+++ b/authors/apps/comments/tests/test_comments.py
@@ -59,13 +59,6 @@ class CommentArticleTest(BaseTestCase):
         self.assertEqual(response.data['message'],
                          'Comment successfully deleted')
 
-    def test_access_comments_without_authentication(self):
-        """Tests users should be logged in to access the comments api"""
-        response = self.client.get(self.url)
-        self.assertEqual(
-            response.data['detail'],
-            'Authentication credentials were not provided.')
-
     def test_comment_on_comment(self):
         """Tests creating a thread of successive comments"""
         self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -1,7 +1,7 @@
 from rest_framework import generics
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from . import serializers
 from .utils import Utils
@@ -12,7 +12,7 @@ from rest_framework.generics import get_object_or_404
 
 
 class CreateCommentAPiView(generics.ListCreateAPIView):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = serializers.CommentSerializer
 
     queryset = Comment.objects.all()
@@ -43,7 +43,7 @@ class CreateCommentAPiView(generics.ListCreateAPIView):
 
 
 class CommentApiView(generics.RetrieveUpdateDestroyAPIView):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = serializers.CommentSerializer
     util = Utils()
 
@@ -98,7 +98,7 @@ class CommentApiView(generics.RetrieveUpdateDestroyAPIView):
 class CommentThreadApiView(generics.ListCreateAPIView):
 
     queryset = Comment.objects.all()
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = serializers.CommentSerializer
     util = Utils()
 
@@ -132,7 +132,7 @@ class CommentThreadApiView(generics.ListCreateAPIView):
 
 class LikeCommentApiView(generics.RetrieveUpdateAPIView):
 
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticatedOrReadOnly,)
     serializer_class = serializers.LikeCommentSerializer
     renderer_classes = (LikeComementsJSONRenderer, )
 
@@ -171,6 +171,6 @@ class LikeCommentApiView(generics.RetrieveUpdateAPIView):
 
 class GetCommentApiView(generics.RetrieveAPIView):
 
-    permission_classes = (IsAuthenticated, )
+    permission_classes = (IsAuthenticatedOrReadOnly, )
     serializer_class = serializers.LikeCommentSerializer
     queryset = LikeComment.objects.all()


### PR DESCRIPTION
#### What does this PR do?
This PR enables any user to read articles, comments and view likes but only authenticated users can create them.

#### Description of Task to be completed?
Authenticated users should be able to read as well as create the articles likes and comments
Unauthenticated users should only be able to read and when they try to create, they should be prompted to login (provide authentication credentials)

#### How should this be manually tested?
run the following commands
`git clone https://github.com/andela/Ah-backend-guardians.git`
`cd Ah-backend-guardians`
`source venv/bin/activate`
`python manage.py runserver`

Open POSTMAN and test the following endpoints both with authentication and without.
```
GET/POST 127.0.0.1:8000/api/articles/
```
```
GET/POST 127.0.0.1:8000/api/<slug>/comments/
```
```
GET/PUT 127.0.0.1:8000/api/<slug>/comments/<id>/likes/
```

The POST article data should be in the form
```
{
	"title": "Hello World",
	"body": "print('Hello world')",
	"description": "My first program"
}
```
The POST comment data should be in the form
```
{
	"body": "Cool now try it with Java"
}
```

Expected Responses For Unauthenticated Users
All POSTS and PUTS should be in the form
```
{
    "detail": "Authentication credentials were not provided."
}
```
All the GETS should provide the data

Expected Responses For Authenticated Users should be as was before.

#### What are the relevant pivotal tracker stories?
#163588288