### PR TITLE
#163937318 Authenticated users should be able to view articles they authored

### DIFF
--- a/authors/apps/articles/tests/test_articles.py
+++ b/authors/apps/articles/tests/test_articles.py
@@ -444,3 +444,12 @@ class TestArticle(BaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(ReadingStat.objects.all().filter(
             user=user.username, articles=article.slug))
+
+    def test_get_my_articles(self):
+        """Tests that a user can get only articles they authored"""
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.get_user_token())
+        response = self.client.get(
+            self.url + 'my_articles/', format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['results'], [])

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -3,11 +3,14 @@ from rest_framework.routers import DefaultRouter
 from .views import (CreateArticleAPIView,
                     RetrieveArticleAPIView, LikeArticleAPIView,
                     DisLikeArticleAPIView, CreateRatingsView,
-                    LikeArticleStatus, DisLikeArticleStatus, FavouritesView)
+                    LikeArticleStatus, DisLikeArticleStatus, FavouritesView,
+                    RetrieveMyArticles)
 
 
 urlpatterns = [
     path('articles/', CreateArticleAPIView.as_view(), name="create_article"),
+    path('articles/my_articles/', RetrieveMyArticles.as_view(),
+         name="view_my_articles"),
     path('articles/<slug>/', RetrieveArticleAPIView.as_view(), name="detail"),
     path('articles/<slug>/rating/', CreateRatingsView.as_view(),
          name="ratings_list"),

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -116,6 +116,19 @@ class RetrieveArticleAPIView(generics.RetrieveUpdateDestroyAPIView):
         )
 
 
+class RetrieveMyArticles(generics.ListAPIView):
+    serializer_class = CreateArticleAPIViewSerializer
+    permission_classes = (IsAuthenticated, )
+    renderer_classes = (ArticlesJSONRenderer,)
+    queryset = Article.objects.all()
+    pagination_class = LimitOffsetPagination
+    pagination_class.default_limit = 10
+    pagination_class.offset_query_param = 'page'
+
+    def get_queryset(self, *args, **kwargs):
+        return self.queryset.filter(author=self.request.user)
+
+
 class CreateRatingsView(generics.UpdateAPIView):
     """
     Class to handle the rating of articles


### PR DESCRIPTION
#### What does this PR do?
This PR enables authenticated users to view only the articles they created.

#### Description of Task to be completed?
* Create a Read IsAuthenticated endpoint for the Article's model

#### How should this be manually tested?
Run the commands below:
* `git clone https://github.com/andela/Ah-backend-guardians.git`
* `git checkout ft-view-my-articles-163937318`
* `python3 manage.py runserver`

Open POSTMAN, signup and or login to the application via
```
POST 127.0.0.1:8000/api/users/
```
and or
```
POST 127.0.0.1:8000/api/users/login/
```
Then hit the endpoint below:
```
GET api/articles/my_articles/
```

*Expected Output:*
If you have articles you have created, it should be similar to this:
![image](https://user-images.githubusercontent.com/26769886/52704261-36f06b80-2f91-11e9-8d73-ae3ad6270d81.png)

#### Relevant pivotal tracker stories
[#163937318](https://www.pivotaltracker.com/story/show/163937318)

####  Other context
Only articles by the currently logged in user should appear and not just all articles.