### PR TITLE
bug(profiles): Users can view username amongst other credentials

### DIFF
--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -8,6 +8,7 @@ from authors.apps.articles.serializers import CreateArticleAPIViewSerializer
 class ProfileSerializer(serializers.ModelSerializer):
     """Serializer for creating a profile"""
     email = serializers.CharField(source='user.email', read_only=True)
+    username = serializers.CharField(source='user.username', read_only=True)
     first_name = serializers.CharField(allow_blank=True, required=False,
                                        min_length=2, max_length=50)
     last_name = serializers.CharField(allow_blank=True, required=False,
@@ -16,7 +17,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Profile
-        fields = ('email', 'bio', 'image', 'first_name', 'last_name')
+        fields = ('email', 'username','bio', 'image', 'first_name', 'last_name')
 
 
 class ReadingStatsSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
**What does this PR do?**
This PR creates a `profile` app separate from the `users` app to enable users to manage their profiles as per separation of concerns

Link to pivotal tracker story
[#163944660](https://www.pivotaltracker.com/story/show/163944660)

**How should this be manually tested?**
Follow these steps in the command terminal:-

Clone this repository by running in this command below
git clone https://github.com/andela/Ah-backend-guardians.git

Change working directory to Ah-backend-guardians
cd Ah-backend-guardians

Create a virtual environment.
virtualenv --python=pyhton3 venv

Activate the virtual environment
source venv/bin/activate

Add the following enviroment varialbles to your .env

```
EMAIL_HOST_USER= gauthorshaven@gmail.com

EMAIL_HOST_PASSWORD = guardiansauthors

EMAIL_PORT = 587

cloud_name = myrdstom

API_KEY = 771354771337349

API_SECRET = _khav7PfkzwqKMlOwHHsl5IhbvM

TWITTER_CONSUMER_KEY = annEeggI3NfH8xqWDTPU2O0Ve

TWITTER_CONSUMER_SECRET = w5tVQ6AnWluKdYUJo8aJrVurofat0Wl7qIwePvgqG3Sb57YtBg

WORD_LENGTH = 5

WPM = 200

```
Install the dependencies in the requirements.txt file using pip
`pip install -r requirements.txt`

Run this command
`python manage.py test` to run the tests

To run the application, run the command below
`python manage.py runserver`

Copy and paste this link into postman `http://127.0.0.1:8000/api/profiles/`  and  the  data  returned when viewing a profile should look like the sample below:
```
{
    "profile": [
        {
            "email": "nserekopaul@ymail.com",
            "username": "paul",
            "bio": null,
            "image": null,
            "first_name": "",
            "last_name": ""
        }
```