### PR TITLE
chore(ArticleComment):  include author on view comment

### DIFF
--- a/authors/apps/comments/serializers.py
+++ b/authors/apps/comments/serializers.py
@@ -1,10 +1,12 @@
 from rest_framework import serializers
 
 from .models import Comment, LikeComment, EditHistory
+from ..articles.serializers import CreateArticleAPIViewSerializer
+from ..authentication.serializers import UserSerializer
 
 
 class CommentSerializer(serializers.ModelSerializer):
-
+    author = UserSerializer(read_only=True)
     class Meta:
         fields = ('id', 'author', 'parent', 'body',
                   'created_at', 'updated_at', 'article')

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -26,10 +26,10 @@ class CreateCommentAPiView(generics.ListCreateAPIView):
         slug = self.kwargs['slug']
         article = self.util.check_article(slug)
         comment = request.data
-        comment.update({'author': request.user.pk, 'article': article.id})
+        comment.update({ 'article': article.id})
         serializer = self.serializer_class(data=comment)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        serializer.save(author=request.user)
         return Response({"message": "Comment Successfully added"},
                         status=status.HTTP_201_CREATED)
 
@@ -113,12 +113,11 @@ class CommentThreadApiView(generics.ListCreateAPIView):
         article = self.util.check_article(slug)
         parent = self.util.check_comment(id)
         comment = request.data
-        comment.update({'author': request.user.pk,
-                        'article': article.id,
+        comment.update({'article': article.id,
                         'parent': id})
         serializer = self.serializer_class(data=comment)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        serializer.save(author=request.user)
         return Response({"message": "Comment Thread Successfully added"},
                         status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
#### What does this PR do?
This PR enables only authenticated users to comment on an article(s).

#### Description of Task to be completed?
Authenticated users are able to comment on articles that have been published. The users are able to perform all the CRUD functionality on the comments of the articles.
Available endpoints include

```
GET api/<slug>/comments/         Gets all comments for a particular article
```
```
POST api/<slug>/comments/         Creates a comment for a particular article
```
```
GET api/<slug>/comments/<id>/         Get a specific comment of an article
```
```
PUT api/<slug>/comments/<id>/         Update a specific comment of an article
```
```
DELETE api/<slug>/comments/<id>/         Delete a specific comment of an article
```
```
POST api/<slug>/comments/<id>/thread/         Comment on a comment
```
```
GET api/<slug>/comments/<id>/thread/         Get entire thread of a comment
```
#### How should this be manually tested?
Run the following commands in your terminal.

* `git clone https://github.com/andela/Ah-backend-guardians.git`
* `cd Ah-backend-guardians`
* `virtualenv venv`
* `source venv/bin/activate`
* `git checkout ft-comment-on-articles-162685666`
* `python3 manage.py runserver`

Next open POSTMAN and begin to test out the end points listed above.
The data required in a POST and PUT is in the form

```
{
	"body":  ""
}
```
Note: You must be logged in to access the endpoints and atleast one article should be present in your database.

#### What are the relevant pivotal tracker stories?
#164298385

#### Screenshots (if appropriate)
This shows a GET all comments for an article including the details of the author
![image](https://user-images.githubusercontent.com/41106626/53646030-46d3a500-3c4b-11e9-8ad9-2aeb0a5cea4e.png)